### PR TITLE
Fix remaining survey issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "syndication-sources/delibrerati"]
-	path = syndication-sources/deliberati
-	url = https://github.com/johnwarden/deliberati

--- a/README.md
+++ b/README.md
@@ -1,59 +1,69 @@
 # Social Protocols Website
 
-This website is built using [Distill for R Markdown](https://rstudio.github.io/distill/).
+This website is built using [Hugo](https://gohugo.io/) and automatically deployed to GitHub Pages.
 
-## Workflows
+## Development
 
-### Set Up Environment
+### Running Locally
 
-Execute the following to have a `ROOTDIR` environment variable available when you want to create paths:
+The easiest way to run the site locally is using [just](https://github.com/casey/just):
 
-```
-$ ROOTDIR=$(pwd)
-$ echo "ROOTDIR=${ROOTDIR}" >> .Renviron
-```
-
-Now you can refer to files with absolute paths:
-
-```
-file.path(ROOTDIR, "path", "to", "file")
+```bash
+just serve
 ```
 
-### Running Locally through nix
+This runs `hugo server` which starts a local development server with live reload at `http://localhost:1313/`.
 
-```
-	just serve
-```
+Alternatively, if you have Hugo installed, you can run directly:
 
-### Bugs
-
-For some reason, changes to .Rmd files don't get picked up automatically when running 'just serve', but changes to .md files to.
-
-If however if you do the following,
-
-```
-   > nix-shell
-   > R
-   > source("serve.R") 
+```bash
+hugo server
 ```
 
-You get some warning messages, but changes to .Rmd files to get picked up. However, it produces some Permission Denied warning messages that seem to be ignorable.
+### Building
 
-## Notes on Publishing Posts to Social Networks 
+To build the site for production:
 
-## Update the Summary
+```bash
+just build
+```
 
-- Take a part of the first Paragraph to use as the summary. The default summary is not always great (it may include the first heading in the article, and cut off in an odd place). The summary is displayed on the home page and Twitter previews. We will also copy and paste in when publishing below.
+This runs `hugo --minify` and generates static files in the `public/` directory.
 
-### Twitter:
+## Deployment
 
-- make sure the Twitter Card displays properly (image and summary)
+The site is automatically deployed to GitHub Pages when changes are pushed to the `main` branch. See `.github/workflows/build.yml` for the deployment configuration.
 
-### Mastodon:
+- **Hugo Version**: 0.131.0 (extended)
+- **Target Branch**: `gh-pages`
+- **Live Site**: https://social-protocols.org/
 
-- manually copy image and summary (Mastodon doesn't load Twitter card preview)
+## Theme
 
-### Medium:
+The site uses a customized version of the [hugo-lithium](https://github.com/yihui/hugo-lithium) theme located in `themes/hugo-lithium/`.
+
+## Content Structure
+
+- `content/articles/` - Main articles and blog posts
+- `content/research-notes/` - Research notes and exploratory write-ups
+- `content/about.md` - About page
+- `content/_index.md` - Homepage
+
+## Notes on Publishing Posts to Social Networks
+
+### Update the Summary
+
+- Take a part of the first paragraph to use as the summary. The default summary is not always great (it may include the first heading in the article, and cut off in an odd place). The summary is displayed on the home page and Twitter previews. We will also copy and paste it when publishing below.
+
+### Twitter
+
+- Make sure the Twitter Card displays properly (image and summary)
+
+### Mastodon
+
+- Manually copy image and summary (Mastodon doesn't load Twitter card preview)
+
+### Medium
 
 - Create new Article
 - Enter the Title
@@ -65,11 +75,11 @@ You get some warning messages, but changes to .Rmd files to get picked up. Howev
   - Add alt text to the featured image (if it has any)
 - Update Settings
   - Update the SEO title to "{Article Title} | Social Protocols"
-  - Under advanced settings, and click "This story was originally published elsewhere". Enter the social protocols URL for the story.
+  - Under advanced settings, click "This story was originally published elsewhere". Enter the social protocols URL for the story.
 - Publish
   - It will ask for topics. Choose topics used in other posts. Currently: Social Media, Collective Intelligence, Attention Economy, Group Dynamics, Systems Thinking
 
-### Substack:
+### Substack
 
 - Create new article
 - Enter subtitle
@@ -79,3 +89,7 @@ You get some warning messages, but changes to .Rmd files to get picked up. Howev
   - Choose tags. Same tags as other posts.
   - SEO Settings
     - Copy summary to SEO Description
+
+## Further Documentation
+
+For more detailed Hugo documentation and guidance, see [issue #9](https://github.com/social-protocols/social-protocols.github.io/issues/9).

--- a/content/about.md
+++ b/content/about.md
@@ -1,7 +1,7 @@
 ---
 title: About Social Protocols
 date: 2023-05-01
-hide: true
+hide: false
 ---
 
 

--- a/content/articles/_index.md
+++ b/content/articles/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Articles"
+canonical_url: https://social-protocols.org/articles/
+---

--- a/content/articles/deliberative-consensus-protocols/index.md
+++ b/content/articles/deliberative-consensus-protocols/index.md
@@ -6,7 +6,7 @@ toc: true
 weight: 3
 toc_sticky: true
 image: deliberative-consensus-protocol.png
-canonical_url: https://social-protocols.org/deliberative-consensus-protocols
+canonical_url: https://social-protocols.org/deliberative-consensus-protocols/
 author: Jonathan Warden
 
 ---

--- a/content/articles/the-deliberative-poll/index.md
+++ b/content/articles/the-deliberative-poll/index.md
@@ -5,7 +5,7 @@ date:   2020-11-08 13:40:43 -0700
 toc: true
 # toc_sticky: true
 image: dylan-gillis-KdeqA3aTnBY-unsplash-wide-1920.jpg
-canonical_url: https://social-protocols.org/the-deliberative-poll
+canonical_url: https://social-protocols.org/the-deliberative-poll/
 author: Jonathan Warden
 
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -23,10 +23,10 @@ summaryLength = 30
   name = "Research Notes"
   url = "/research-notes"
   weight = 2
-# [[menu.main]]
-#   name = "About"
-#   url = "/about/"
-#   weight = 3
+[[menu.main]]
+  name = "About"
+  url = "/about/"
+  weight = 3
 
 [[menu.footer]]
   name = "GitHub"

--- a/justfile
+++ b/justfile
@@ -3,9 +3,5 @@ serve:
 	hugo server
 
 build:
-	nix-shell --command "Rscript -e 'blogdown::build_site(build_rmd = \"newfile\")'"
-
-
-
-
+	hugo --minify
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

This PR addresses the remaining issues from the repository survey, fixing site configuration, documentation, and canonical URL consistency.

## Issues Fixed

- **Fixes #13**: Unhide the About page
  - Changed `hide: false` in `content/about.md`
  - Uncommented About menu item in `hugo.toml`
  - Uses existing About page copy without inventing new organizational story

- **Fixes #14**: Remove obsolete deliberati submodule
  - Deleted `.gitmodules` file containing typo "delibrerati" reference
  - Deliberati.io is sunset and no longer needed

- **Fixes #15**: Normalize article canonical URLs with trailing slashes
  - Added trailing slashes to `deliberative-consensus-protocols` and `the-deliberative-poll`
  - All article canonical URLs now consistently end with `/` to match live URLs

- **Fixes #17**: Replace obsolete blogdown build target
  - Replaced `blogdown::build_site()` in justfile with `hugo --minify`
  - Aligns with actual Hugo-based build pipeline

- **Fixes #18**: Rewrite README for Hugo + GitHub Pages
  - Removed outdated Distill/R Markdown documentation
  - Added Hugo development and deployment instructions
  - Referenced issue #9 for further Hugo documentation
  - Kept existing social media publishing guidelines

- **Fixes #21**: Add rel=canonical to /articles/ listing page
  - Created `content/articles/_index.md` with canonical_url parameter
  - Theme's existing `head.html` now renders the canonical tag on the articles index

## Issues NOT Addressed

- **Issue #16**: Johannes Nakayama's draft article "What We Are Building and Why" is **intentionally left as draft** (`draft: true`). This is not Jonathan's essay to publish.

- **Issues #19 and #20**: These should already be addressed in PR #22 (content move / baseURL / projects). If baseURL and projects fixes are confirmed in #22, they are not duplicated here.

## Notes

- The baseURL change (from `https://example.org/` to `https://social-protocols.org/`) was already addressed in PR #22 according to that PR's description
- The projects section additions (Blue Notes, Context Bot) were also already added in PR #22
- This PR focuses on the remaining configuration, documentation, and canonical URL fixes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44cf3617-075c-41c2-9848-abc337468fab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44cf3617-075c-41c2-9848-abc337468fab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

